### PR TITLE
Improve CMake GitHub actions workflow

### DIFF
--- a/.github/workflows/cmake-multi-platform-val.yml
+++ b/.github/workflows/cmake-multi-platform-val.yml
@@ -1,6 +1,15 @@
 name: Multiplatform CMake Build, CTest, Valgrind Profiling
 
 on:
+  push:
+    branches:
+     - main
+  pull_request:
+    branches:
+     - main
+    paths-ignore:
+     - 'README.md'
+     
   workflow_dispatch:
 
 jobs:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,8 +3,8 @@ cmake_minimum_required(VERSION 3.28) # Needed to reduce version for compatibilit
 project(prime-headers)
 
 set(CMAKE_C_STANDARD 11)
-
 set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_BUILD_TYPE RelWithDebInfo)
 
 # deliberately not including these subdirectories by glob regex as precaution
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,8 @@ project(prime-headers)
 
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
-set(CMAKE_BUILD_TYPE RelWithDebInfo)
+set(CMAKE_BUILD_TYPE Debug)
+##set(CMAKE_BUILD_TYPE Release)
 
 # deliberately not including these subdirectories by glob regex as precaution
 


### PR DESCRIPTION
Added on push to main and PR to main triggers in CMake workflow.
Added build type debug in CMakeLists.txt for precise Valgrind reports.
Ignored README.md PRs for testing.